### PR TITLE
Feat/zero lock reward

### DIFF
--- a/contracts/GIVpower.sol
+++ b/contracts/GIVpower.sol
@@ -95,10 +95,10 @@ contract GIVpower is GardenUnipoolTokenDistributor, IERC20MetadataUpgradeable {
         if (_gainedPowerAmount > 0) {
             // Add power/farming benefit of locking
             super.stake(msg.sender, _gainedPowerAmount);
+            emit Transfer(address(0), msg.sender, _gainedPowerAmount);
         }
 
         emit TokenLocked(msg.sender, amount, rounds, _endRound);
-        emit Transfer(address(0), msg.sender, _gainedPowerAmount);
     }
 
     /// @notice Unlock tokens belongs to accounts which are locked till the end of round
@@ -131,10 +131,10 @@ contract GIVpower is GardenUnipoolTokenDistributor, IERC20MetadataUpgradeable {
             if (_releasablePowerAmount > 0) {
                 // Reduce power/farming benefit of locking
                 super.withdraw(_account, _releasablePowerAmount);
+                emit Transfer(_account, address(0), _releasablePowerAmount);
             }
 
             emit TokenUnlocked(_account, _unlockableTokenAmount, round);
-            emit Transfer(_account, address(0), _releasablePowerAmount);
         }
     }
 

--- a/contracts/GIVpower.sol
+++ b/contracts/GIVpower.sol
@@ -65,7 +65,7 @@ contract GIVpower is GardenUnipoolTokenDistributor, IERC20MetadataUpgradeable {
     /// @param amount Amount of unlocked tokens to lock
     /// @param rounds Number of rounds to lock amount of tokens
     function lock(uint256 amount, uint256 rounds) external {
-        if (rounds < 1) {
+        if (rounds == 0) {
             revert ZeroLockRound();
         }
         if (amount == 0) {

--- a/contracts/GIVpower.sol
+++ b/contracts/GIVpower.sol
@@ -43,6 +43,8 @@ contract GIVpower is GardenUnipoolTokenDistributor, IERC20MetadataUpgradeable {
     error NotEnoughBalanceToLock();
     /// Must lock for positive number of rounds
     error ZeroLockRound();
+    /// Must lock for positive amount
+    error ZeroLockAmount();
     /// Locking has limitation on number of rounds - maxLockRounds
     error LockRoundLimit();
     /// Token is not transferable
@@ -66,6 +68,9 @@ contract GIVpower is GardenUnipoolTokenDistributor, IERC20MetadataUpgradeable {
         if (rounds < 1) {
             revert ZeroLockRound();
         }
+        if (amount == 0) {
+            revert ZeroLockAmount();
+        }
         if (rounds > MAX_LOCK_ROUNDS) {
             revert LockRoundLimit();
         }
@@ -87,8 +92,10 @@ contract GIVpower is GardenUnipoolTokenDistributor, IERC20MetadataUpgradeable {
 
         _roundBalance.releasablePowerAmount = _roundBalance.releasablePowerAmount.add(_gainedPowerAmount);
 
-        // Add power/farming benefit of locking
-        super.stake(msg.sender, _gainedPowerAmount);
+        if (_gainedPowerAmount > 0) {
+            // Add power/farming benefit of locking
+            super.stake(msg.sender, _gainedPowerAmount);
+        }
 
         emit TokenLocked(msg.sender, amount, rounds, _endRound);
         emit Transfer(address(0), msg.sender, _gainedPowerAmount);
@@ -121,8 +128,10 @@ contract GIVpower is GardenUnipoolTokenDistributor, IERC20MetadataUpgradeable {
             _roundBalance.releasablePowerAmount = 0;
             _roundBalance.unlockableTokenAmount = 0;
 
-            // Reduce power/farming benefit of locking
-            super.withdraw(_account, _releasablePowerAmount);
+            if (_releasablePowerAmount > 0) {
+                // Reduce power/farming benefit of locking
+                super.withdraw(_account, _releasablePowerAmount);
+            }
 
             emit TokenUnlocked(_account, _unlockableTokenAmount, round);
             emit Transfer(_account, address(0), _releasablePowerAmount);

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,7 @@
 [profile.default]
 src = 'contracts'
 out = 'out'
+fuzz_runs = 5000
 libs = ['lib']
 remappings = [
     'ds-test/=lib/forge-std/lib/ds-test/src/',

--- a/test/Balance.t.sol
+++ b/test/Balance.t.sol
@@ -63,11 +63,8 @@ contract BalanceTest is GIVpowerTest {
 
     function testLockUnlock(uint256 amount, uint8 rounds) public {
         uint256 maxLockRounds = givPower.MAX_LOCK_ROUNDS();
-
-        vm.assume(amount < MAX_GIV_BALANCE);
-        vm.assume(amount > 0);
-        vm.assume(rounds <= maxLockRounds);
-        vm.assume(rounds > 0);
+        amount = bound(amount, 1, MAX_GIV_BALANCE);
+        rounds = uint8(bound(rounds, 1, maxLockRounds));
 
         vm.startPrank(sender);
         givToken.approve(address(tokenManager), amount);
@@ -80,7 +77,7 @@ contract BalanceTest is GIVpowerTest {
 
         uint256 lockReward = givPower.calculatePower(amount, rounds) - amount;
 
-        vm.assume(lockReward > 0);
+        //        vm.assume(lockReward > 0);
 
         uint256 unlockRound = givPower.currentRound() + rounds;
         givPower.lock(amount, rounds);
@@ -167,6 +164,16 @@ contract BalanceTest is GIVpowerTest {
     }
 
     function testTowAccountLock(uint256 amount1, uint8 rounds1, uint256 amount2, uint8 rounds2) public {
+        amount1 = bound(amount1, 1, MAX_GIV_BALANCE - 1);
+        amount2 = bound(amount2, 1, MAX_GIV_BALANCE - 1);
+        rounds1 = uint8(bound(rounds1, 1, givPower.MAX_LOCK_ROUNDS()));
+        rounds2 = uint8(bound(rounds2, 1, givPower.MAX_LOCK_ROUNDS()));
+
+        vm.assume(amount1 < (MAX_GIV_BALANCE - amount2)); // Same as (amount1 + amount2) < MAX_GIV_BALANCE; to avoid overflow
+
+        // rounds2 should be longer then rounds1
+        vm.assume(rounds1 < rounds2);
+
         address user1 = address(100);
         address user2 = address(200);
 
@@ -174,21 +181,8 @@ contract BalanceTest is GIVpowerTest {
         accounts[0] = user1;
         accounts[1] = user2;
 
-        vm.assume(rounds1 > 0);
-        vm.assume(rounds2 > 0);
-        vm.assume(rounds1 <= givPower.MAX_LOCK_ROUNDS());
-        vm.assume(rounds2 <= givPower.MAX_LOCK_ROUNDS());
-        // rounds2 should be longer then rounds1
-        vm.assume(rounds1 < rounds2);
-
-        vm.assume(amount1 > 0);
-        vm.assume(amount2 > 0);
-        vm.assume(amount1 < MAX_GIV_BALANCE);
-        vm.assume(amount2 < MAX_GIV_BALANCE);
-        vm.assume(amount1 < (MAX_GIV_BALANCE - amount2)); // Same as (amount1 + amount2) < MAX_GIV_BALANCE; to avoid overflow
-
-        vm.assume(amount1 < givPower.calculatePower(amount1, rounds1));
-        vm.assume(amount2 < givPower.calculatePower(amount2, rounds2));
+        // vm.assume(amount1 < givPower.calculatePower(amount1, rounds1));
+        // vm.assume(amount2 < givPower.calculatePower(amount2, rounds2));
 
         vm.startPrank(sender);
         givToken.transfer(user1, amount1);

--- a/test/Balance.t.sol
+++ b/test/Balance.t.sol
@@ -77,8 +77,6 @@ contract BalanceTest is GIVpowerTest {
 
         uint256 lockReward = givPower.calculatePower(amount, rounds) - amount;
 
-        //        vm.assume(lockReward > 0);
-
         uint256 unlockRound = givPower.currentRound() + rounds;
         givPower.lock(amount, rounds);
 
@@ -180,9 +178,6 @@ contract BalanceTest is GIVpowerTest {
         address[] memory accounts = new address[](2);
         accounts[0] = user1;
         accounts[1] = user2;
-
-        // vm.assume(amount1 < givPower.calculatePower(amount1, rounds1));
-        // vm.assume(amount2 < givPower.calculatePower(amount2, rounds2));
 
         vm.startPrank(sender);
         givToken.transfer(user1, amount1);

--- a/test/GeneralTest.t.sol
+++ b/test/GeneralTest.t.sol
@@ -117,11 +117,11 @@ contract GeneralTest is GIVpowerTest {
         vm.expectEmit(true, true, true, true);
         emit Staked(sender, powerIncreaseAfterLock);
 
-        vm.expectEmit(true, true, true, true);
-        emit TokenLocked(sender, lockAmount, numberOfRounds, untilRound);
-
         vm.expectEmit(true, true, true, true, address(givPower));
         emit Transfer(address(0), sender, powerIncreaseAfterLock);
+
+        vm.expectEmit(true, true, true, true);
+        emit TokenLocked(sender, lockAmount, numberOfRounds, untilRound);
 
         givPower.lock(lockAmount, numberOfRounds);
 
@@ -149,11 +149,11 @@ contract GeneralTest is GIVpowerTest {
         vm.expectEmit(true, true, true, true);
         emit Withdrawn(sender, powerIncreaseAfterLock);
 
-        vm.expectEmit(true, true, true, true);
-        emit TokenUnlocked(sender, lockAmount, untilRound);
-
         vm.expectEmit(true, true, true, true, address(givPower));
         emit Transfer(sender, address(0), powerIncreaseAfterLock);
+
+        vm.expectEmit(true, true, true, true);
+        emit TokenUnlocked(sender, lockAmount, untilRound);
 
         givPower.unlock(accounts, untilRound);
 

--- a/test/Lock.t.sol
+++ b/test/Lock.t.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.6;
+
+import './GIVpowerTest.sol';
+
+// To test Lock Edge Cases
+contract LockTest is GIVpowerTest {
+    function setUp() public override {
+        super.setUp();
+
+        vm.startPrank(omniBridge);
+        givToken.mint(sender, MAX_GIV_BALANCE - givToken.balanceOf(sender));
+        vm.stopPrank();
+    }
+
+    function testZeroAmountLock(uint8 rounds) public {
+        rounds = uint8(bound(rounds, 1, givPower.MAX_LOCK_ROUNDS()));
+
+        vm.expectRevert(GIVpower.ZeroLockAmount.selector);
+
+        vm.prank(sender);
+        givPower.lock(0, rounds);
+    }
+
+    function testZeroRoundLock(uint256 amount) public {
+        amount = bound(amount, 1, MAX_GIV_BALANCE);
+
+        vm.expectRevert(GIVpower.ZeroLockRound.selector);
+
+        vm.prank(sender);
+        givPower.lock(amount, 0);
+    }
+
+    function testRoundLockMoreThanLimit(uint256 amount, uint256 rounds) public {
+        amount = bound(amount, 1, MAX_GIV_BALANCE);
+        vm.assume(rounds > givPower.MAX_LOCK_ROUNDS());
+
+        vm.expectRevert(GIVpower.LockRoundLimit.selector);
+
+        vm.prank(sender);
+        givPower.lock(amount, rounds);
+    }
+
+    function testNormalLock(uint256 amount, uint8 rounds) public {
+        amount = bound(amount, 1, MAX_GIV_BALANCE);
+        rounds = uint8(bound(rounds, 1, givPower.MAX_LOCK_ROUNDS()));
+
+        vm.startPrank(sender);
+
+        givToken.approve(address(tokenManager), amount);
+        tokenManager.wrap(amount);
+
+        uint256 untilRound = givPower.currentRound() + rounds;
+        uint256 powerIncreaseAfterLock = givPower.calculatePower(amount, rounds) - amount;
+
+        if (powerIncreaseAfterLock > 0) {
+            vm.expectEmit(true, true, true, true);
+            emit Staked(sender, powerIncreaseAfterLock);
+        }
+
+        vm.expectEmit(true, true, true, true);
+        emit TokenLocked(sender, amount, rounds, untilRound);
+
+        if (powerIncreaseAfterLock > 0) {
+            vm.expectEmit(true, true, true, true, address(givPower));
+            emit Transfer(address(0), sender, powerIncreaseAfterLock);
+        }
+
+        givPower.lock(amount, rounds);
+    }
+}

--- a/test/Lock.t.sol
+++ b/test/Lock.t.sol
@@ -56,15 +56,13 @@ contract LockTest is GIVpowerTest {
         if (powerIncreaseAfterLock > 0) {
             vm.expectEmit(true, true, true, true);
             emit Staked(sender, powerIncreaseAfterLock);
+
+            vm.expectEmit(true, true, true, true, address(givPower));
+            emit Transfer(address(0), sender, powerIncreaseAfterLock);
         }
 
         vm.expectEmit(true, true, true, true);
         emit TokenLocked(sender, amount, rounds, untilRound);
-
-        if (powerIncreaseAfterLock > 0) {
-            vm.expectEmit(true, true, true, true, address(givPower));
-            emit Transfer(address(0), sender, powerIncreaseAfterLock);
-        }
 
         givPower.lock(amount, rounds);
     }

--- a/test/LockRounds.t.sol
+++ b/test/LockRounds.t.sol
@@ -93,15 +93,13 @@ contract LockRounds is GIVpowerTest {
         if (lockRewards > 0) {
             vm.expectEmit(true, true, true, true);
             emit Withdrawn(sender, lockRewards);
+
+            vm.expectEmit(true, true, true, true, address(givPower));
+            emit Transfer(sender, address(0), lockRewards);
         }
 
         vm.expectEmit(true, true, true, true);
         emit TokenUnlocked(sender, amount, untilRound);
-
-        if (lockRewards > 0) {
-            vm.expectEmit(true, true, true, true, address(givPower));
-            emit Transfer(sender, address(0), lockRewards);
-        }
 
         givPower.unlock(accounts, untilRound);
     }

--- a/test/LockRounds.t.sol
+++ b/test/LockRounds.t.sol
@@ -46,8 +46,7 @@ contract LockRounds is GIVpowerTest {
         uint256 maxLockRounds = givPower.MAX_LOCK_ROUNDS();
         uint256 roundDuration = givPower.ROUND_DURATION();
 
-        vm.assume(rounds > 0);
-        vm.assume(rounds <= maxLockRounds);
+        rounds = bound(rounds, 1, maxLockRounds);
         amount = bound(amount, 1, MAX_GIV_BALANCE);
 
         uint256 lockRewards = givPower.calculatePower(amount, rounds) - amount;

--- a/test/LockRounds.t.sol
+++ b/test/LockRounds.t.sol
@@ -46,7 +46,7 @@ contract LockRounds is GIVpowerTest {
         uint256 maxLockRounds = givPower.MAX_LOCK_ROUNDS();
         uint256 roundDuration = givPower.ROUND_DURATION();
 
-        rounds = bound(rounds, 1, maxLockRounds);
+        rounds = uint8(bound(rounds, 1, maxLockRounds));
         amount = bound(amount, 1, MAX_GIV_BALANCE);
 
         uint256 lockRewards = givPower.calculatePower(amount, rounds) - amount;

--- a/test/Transfer.t.sol
+++ b/test/Transfer.t.sol
@@ -72,13 +72,13 @@ contract TransferTest is GIVpowerTest {
 
         uint256 lockReward = givPower.calculatePower(amount, rounds) - amount;
 
-        vm.assume(lockReward > 0);
+        if (lockReward > 0) {
+            vm.expectEmit(true, true, true, true, address(givPower));
+            emit Staked(sender, lockReward);
 
-        vm.expectEmit(true, true, true, true, address(givPower));
-        emit Staked(sender, lockReward);
-
-        vm.expectEmit(true, true, true, true, address(givPower));
-        emit Transfer(address(0), sender, lockReward);
+            vm.expectEmit(true, true, true, true, address(givPower));
+            emit Transfer(address(0), sender, lockReward);
+        }
 
         uint256 unlockRound = givPower.currentRound() + rounds;
         givPower.lock(amount, rounds);
@@ -94,10 +94,12 @@ contract TransferTest is GIVpowerTest {
 
         skip(givPower.ROUND_DURATION() * (rounds + 1));
 
-        vm.expectEmit(true, true, true, true, address(givPower));
-        emit Withdrawn(sender, lockReward);
-        vm.expectEmit(true, true, true, true, address(givPower));
-        emit Transfer(sender, address(0), lockReward);
+        if (lockReward > 0) {
+            vm.expectEmit(true, true, true, true, address(givPower));
+            emit Withdrawn(sender, lockReward);
+            vm.expectEmit(true, true, true, true, address(givPower));
+            emit Transfer(sender, address(0), lockReward);
+        }
 
         address[] memory unlockAccounts = new address[](1);
         unlockAccounts[0] = sender;
@@ -109,8 +111,6 @@ contract TransferTest is GIVpowerTest {
         vm.assume(lockAmount > 0);
 
         lockReward = givPower.calculatePower(lockAmount, rounds) - lockAmount;
-
-        vm.assume(lockReward > 0);
 
         unlockRound = givPower.currentRound() + rounds;
         givPower.lock(lockAmount, rounds);


### PR DESCRIPTION
Added error for zero amount locking
Added condition to not stake/withdraw locking reward, it's the locking reward is zero
Added test for Lock edge cases and errors
Increased fuzzing test rounds to 5000
Replaces `vm.assume` statements with `bound`, for better performance on fuzz testing and fixing issue of lots of global error cases appeared after increasing fuzzing test rounds 